### PR TITLE
getlocation simplifications

### DIFF
--- a/getlocation.py
+++ b/getlocation.py
@@ -1,22 +1,17 @@
 #!/usr/bin/env python
 from pyipinfodb import pyipinfodb
+from sys import stdin, stderr
+from functools import lru_cache
 
-ip_lookup = pyipinfodb.IPInfo('API_KEY_HERE')
+@lru_cache(maxsize=None)
+def get_location(ip):
+    print('Getting location for', ip, file=stderr)
+    ip_data = ip_lookup.get_city(ip)
+    yield ip_data['longitude'], ip_data['latitude']
 
-coord_list = [] # List of tuples containing coordinates as (Longitude, Latitude)
-cache = {} # Dict containing data from IPs that have already been requested
-           # from the API
-with open('ips.txt','r') as ip_file:
-    for ip in ip_file:
-        print('Getting location for {}'.format(ip))
-        if ip not in cache:
-            ip_data=ip_lookup.get_city(ip)
-            cache[ip] = ip_data
-        else:
-            ip_data = cache[ip]
-        coord_list.append((ip_data['longitude'], ip_data['latitude']))
+def main():
+    for ip in stdin:
+        print(*get_location(ip), sep=',')
 
-with open('geo.txt', 'w') as geo_file:
-    for coordinates in coord_list:
-        ip_longitude, ip_latitude = coordinates
-        geo_file.write('{},{}\n'.format(ip_longitude, ip_latitude))
+if __name__ == '__main__':
+    main()

--- a/getlocation.py
+++ b/getlocation.py
@@ -1,21 +1,52 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from argparse import ArgumentParser
+from contextlib import contextmanager
 from pyipinfodb import pyipinfodb
-from sys import stdin, stderr
-from functools import lru_cache
+from sys import stdin, stdout, stderr
 
-#TODO: move this to main, get api key from a CLI argument
-ip_lookup = pyipinfodb.IPInfo('API_KEY_HERE')
+def memoize(func):
+    '''
+    Decorator for a function which caches results. Based on
+    http://code.activestate.com/recipes/578231-probably-the-fastest-memoization-decorator-in-the-/
+    '''
+    class memodict(dict):
+        def __missing__(self, key):
+            ret = self[key] = func(*key)
+            return ret
+        def __call__(self, *args):
+            return self[args]
+    
+    return memodict()
 
-@lru_cache(maxsize=None)
-def get_location(ip):
+@memoize
+def get_location(ip_lookup, ip):
     print('Getting location for', ip, file=stderr)
     ip_data = ip_lookup.get_city(ip)
     yield ip_data['longitude'], ip_data['latitude']
 
+
+@contextmanager
+def smart_open(file_or_filename, *args, **kwargs):
+    if isinstance(file_or_filename, (int, str, unicode, bytes)):
+        with open(file_or_filename, *args, **kwargs) as f:
+            yield f
+    else:
+        yield file_or_filename
+
 def main():
-    for ip in stdin:
-        print(*get_location(ip), sep=',')
+    parser = ArgumentParser()
+    parser.add_argument('--input', '-i', default=stdin)
+    parser.add_argument('--output', '-o', default=stdout)
+    parser.add_argument('API_KEY')
+    args = parser.parse_args()
+    
+    ip_lookup = pyipinfodb.IPInfo(args.API_KEY)
+    
+    with smart_open(args.input) as istr:
+        with smart_open(args.output, 'w') as ostr:
+            for ip in istr:
+                print(*get_location(ip_lookup, ip), sep=",", file=ostr)
 
 if __name__ == '__main__':
     main()

--- a/getlocation.py
+++ b/getlocation.py
@@ -28,7 +28,7 @@ def get_location(ip_lookup, ip):
 
 @contextmanager
 def smart_open(file_or_filename, *args, **kwargs):
-    if isinstance(file_or_filename, (int, str, unicode, bytes)):
+    if isinstance(file_or_filename, (int, str, bytes)):
         with open(file_or_filename, *args, **kwargs) as f:
             yield f
     else:

--- a/getlocation.py
+++ b/getlocation.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
+from __future__ import print_function
 from pyipinfodb import pyipinfodb
 from sys import stdin, stderr
 from functools import lru_cache
+
+#TODO: move this to main, get api key from a CLI argument
+ip_lookup = pyipinfodb.IPInfo('API_KEY_HERE')
 
 @lru_cache(maxsize=None)
 def get_location(ip):


### PR DESCRIPTION
- Now uses lru_cache for ip caching
- Now uses stdin and stdout rather than fixed filenames. Can be used in a pipeline
- Now respects `__name__ == "__main__"`
- Now uses print instead of write
