### PR TITLE
Added error handling on ips.txt file

### DIFF
--- a/getlocation.py
+++ b/getlocation.py
@@ -6,16 +6,21 @@ ip_lookup = pyipinfodb.IPInfo('API_KEY_HERE')
 coord_list = [] # List of tuples containing coordinates as (Longitude, Latitude)
 cache = {} # Dict containing data from IPs that have already been requested
            # from the API
-with open('ips.txt','r') as ip_file:
-    for ip in ip_file:
-        print('Getting location for {}'.format(ip))
-        if ip not in cache:
-            ip_data=ip_lookup.get_city(ip)
-            cache[ip] = ip_data
-        else:
-            ip_data = cache[ip]
-        coord_list.append((ip_data['longitude'], ip_data['latitude']))
+           
+if os.path.exists('ips.txt'):
+    with open('ips.txt','r') as ip_file:
+        for ip in ip_file:
+            print('Getting location for {}'.format(ip))
+            if ip not in cache:
+                ip_data=ip_lookup.get_city(ip)
+                cache[ip] = ip_data
+            else:
+                ip_data = cache[ip]
+            coord_list.append((ip_data['longitude'], ip_data['latitude']))
 
+else:
+    print('File \'ips.text\' not found!')
+    raise SystemExit()
 with open('geo.txt', 'w') as geo_file:
     for coordinates in coord_list:
         ip_longitude, ip_latitude = coordinates


### PR DESCRIPTION
Added error handling on ips.txt. The script throws error when ips.txt file is not present in PWD. Fixed it by using os.path module's exists() function. If ips.txt is not present, then appropriate error is shown and script exits.
