### PR TITLE
Made getlocation more pythonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Here are some python scripts you can use to plot ip-addresses on a map
 
 ### Short usage guide:
 
-* First, you need to get an API key for [ipinfodb](http://ipinfodb.com/), and insert it in getlocation.py
+* First, you need to get an API key for [ipinfodb](http://ipinfodb.com/)
 
 * Put your IP-addresses in a file called **ips.txt**, with one IP on each line. (Note: only tested with IPv4)
 
-* Run the **getlocation.py** script. It will create a file called **geo.txt**, which contains coordinates on each line.
+* Run the **getlocation.py** script, like so: `python getlocation.py <API_KEY> < ips.txt > geo.txt` It will create a file called **geo.txt**, which contains coordinates on each line.
 
-* Finally, run the **generatemap.py** script. It will create an image file called map.png.
+* Finally, run the **generatemap.py** script, like so: `python generatemap.py < geo.txt` It will create an image file called map.png.
 
 You can play around with the settings in **generatemap.py**, to use different map projections, different colors and so on.
 
@@ -26,4 +26,8 @@ I used this to plot refused SSH connections on my linux machine. I used the foll
 
     grep "refused" /var/log/auth.log | awk '{ print $9 }' | sort | uniq > ips.txt
 
-Note that i grep for lines with "refused". These are connections refused because of rules in /etc/hosts.deny and /etc/hosts.allow. You may need to change the command to suit your configuration.
+You can also run the whole process as a single pipeline:
+    
+    grep "refused" /var/log/auth.log | awk '{ print $9 }' | sort | uniq | python getlocation.py <API_KEY> | python generatemap.py
+
+Note that I grep for lines with "refused". These are connections refused because of rules in /etc/hosts.deny and /etc/hosts.allow. You may need to change the command to suit your configuration.

--- a/getlocation.py
+++ b/getlocation.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from pyipinfodb import pyipinfodb
 from sys import stdin, stdout, stderr
 
+
 def memoize(func):
     '''
     Decorator for a function which caches results. Based on
@@ -19,6 +20,7 @@ def memoize(func):
     
     return memodict()
 
+
 @memoize
 def get_location(ip_lookup, ip):
     print('Getting location for', ip, file=stderr)
@@ -28,11 +30,14 @@ def get_location(ip_lookup, ip):
 
 @contextmanager
 def smart_open(file_or_filename, *args, **kwargs):
-    if isinstance(file_or_filename, (int, str, bytes)):
-        with open(file_or_filename, *args, **kwargs) as f:
-            yield f
-    else:
+    try:
+        f = open(file_or_filename, *args, **kwargs)
+    except TypeError:
         yield file_or_filename
+    else:
+        with f:
+            yield f
+
 
 def main():
     parser = ArgumentParser()


### PR DESCRIPTION
smart_open now obeys EAFP- try to open and check for an error, rather than checking for the correct type. This has the bonus of working in both Python 2 and 3 without any hacks, including with non-ascii filenames (like "thè_filê")
